### PR TITLE
Refactor prepare metrics

### DIFF
--- a/reporter/base.py
+++ b/reporter/base.py
@@ -82,7 +82,6 @@ class Metrics:
         self._metrics_registry = None
         self.start_time = datetime.utcnow()
         self.end_time = None
-        self._prepared_metrics = {}
         self.value_types_map = {
             int: NotImplemented,
             bool: NotImplemented,
@@ -109,11 +108,7 @@ class Metrics:
 
     @property
     def prepared_metrics(self) -> dict:
-        return self._prepared_metrics
-
-    @prepared_metrics.setter
-    def prepared_metrics(self, value: dict):
-        self._prepared_metrics = value
+        return self.prepare_metrics()
 
     @property
     def metrics_registry(self) -> MetricsRegistry:
@@ -173,9 +168,9 @@ class Metrics:
         """
         raise NotImplementedError
 
-    def prepare_metrics(self):
+    def prepare_metrics(self) -> dict:
         """
         Enriches MetricsRegistry.metrics content and processes data to meet requirements of
-        monitoring server and stores it in self.prepared_metrics
+        monitoring server and stores it in self.prepared_metrics, then returns enriched metrics
         """
         raise NotImplementedError

--- a/reporter/cloudwatch.py
+++ b/reporter/cloudwatch.py
@@ -15,7 +15,6 @@ class CloudWatchMetrics(Metrics):
         self.namespace = args.monitoring_namespace.upper()
 
     def send_metrics(self):
-        self.prepare_metrics()
         self.metrics_client.put_metric_data(
             MetricData=list(self.prepared_metrics.values()),
             Namespace=self.namespace,
@@ -23,7 +22,7 @@ class CloudWatchMetrics(Metrics):
 
     def prepare_metrics(self):
         """
-        Fulfills `self.prepared_metrics` with metrics data in Cloudwatch-specific format.
+        Returns metrics registry data fulfilled with metrics data in Cloudwatch-specific format.
         """
         self.units_map = {
             "seconds": "Seconds",
@@ -33,10 +32,12 @@ class CloudWatchMetrics(Metrics):
             None: "None",
         }
 
+        prepared_metrics = {}
+
         for metric_name, metric_dict in self.metrics_registry.metrics.items():
             cloudwatch_metric_name = metric_name.upper()
 
-            self.prepared_metrics[cloudwatch_metric_name] = {
+            prepared_metrics[cloudwatch_metric_name] = {
                 "MetricName": cloudwatch_metric_name,
                 "Dimensions": [
                     {
@@ -47,3 +48,5 @@ class CloudWatchMetrics(Metrics):
                 "Unit": self.units_map[metric_dict["unit"]],
                 "Value": metric_dict["value"],
             }
+
+        return prepared_metrics

--- a/reporter/local.py
+++ b/reporter/local.py
@@ -60,12 +60,12 @@ _BASIC_FORMATTER = logging.Formatter(
 
 
 def get_logger(
-        module_name: str,
-        log_file: str = None,
-        syslog: str = None,
-        stream_logger: bool = True,
-        debug: bool = False,
-        json_formatter: bool = False,
+    module_name: str,
+    log_file: str = None,
+    syslog: str = None,
+    stream_logger: bool = True,
+    debug: bool = False,
+    json_formatter: bool = False,
 ) -> logging.Logger:
     """
     Helper method, that allows to setup logger instance with arbitrary combination of logging
@@ -115,7 +115,9 @@ class LocalMetrics(Metrics):
         self.metrics_file = args.metrics_file
 
     def send_metrics(self):
-        self.metrics_file = "{}.{}".format(self.metrics_file, self.metrics_registry.metric_set)
+        self.metrics_file = "{}.{}".format(
+            self.metrics_file, self.metrics_registry.metric_set
+        )
         with open(self.metrics_file, "w") as f:
             json.dump(self.prepared_metrics, f, indent=2)
 

--- a/reporter/local.py
+++ b/reporter/local.py
@@ -116,15 +116,18 @@ class LocalMetrics(Metrics):
 
     def send_metrics(self):
         self.metrics_file = "{}.{}".format(self.metrics_file, self.metrics_registry.metric_set)
-        self.prepare_metrics()
         with open(self.metrics_file, "w") as f:
             json.dump(self.prepared_metrics, f, indent=2)
 
     def prepare_metrics(self):
+        prepared_metrics = {}
+
         for metric_name, metric_dict in self.metrics_registry.metrics.items():
             prepared_metric_dict = metric_dict.copy()
 
             prepared_metric_dict.pop("metric_type")
             prepared_metric_dict.pop("value_type")
 
-            self.prepared_metrics[metric_name] = prepared_metric_dict
+            prepared_metrics[metric_name] = prepared_metric_dict
+
+        return prepared_metrics

--- a/reporter/stackdriver.py
+++ b/reporter/stackdriver.py
@@ -50,8 +50,8 @@ class StackdriverMetrics(Metrics):
 
     def prepare_metrics(self):
         """
-        Fulfills `self.prepared_metrics` with implementation-specific
-        metrics data, like protobuf descriptors.
+        Returns metrics registry data fulfilled with implementation-specific
+        metrics data, like protobuf descriptor.
         """
         self.units_map = {
             "seconds": "s",
@@ -70,6 +70,9 @@ class StackdriverMetrics(Metrics):
             Gauge: MetricDescriptor.GAUGE,
             Counter: MetricDescriptor.CUMULATIVE,
         }
+
+        prepared_metrics = {}
+
         for metric_name, metric_dict in self.metrics_registry.metrics.items():
             prepared_metric_dict = metric_dict.copy()
 
@@ -88,7 +91,9 @@ class StackdriverMetrics(Metrics):
             stackdriver_metric_name = f"custom.googleapis.com/" \
                 f"{self.metrics_registry.metric_set}/{metric_name}"
 
-            self.prepared_metrics[stackdriver_metric_name] = prepared_metric_dict
+            prepared_metrics[stackdriver_metric_name] = prepared_metric_dict
+
+        return prepared_metrics
 
     def _create_metric_descriptor(
             self, metric_kind, value_type, metric_name, unit
@@ -181,7 +186,6 @@ class StackdriverMetrics(Metrics):
         Constructs protobuf messages and sends them through client.
         """
         time_series_list = []
-        self.prepare_metrics()
 
         for (
                 metric_name,

--- a/reporter/stackdriver.py
+++ b/reporter/stackdriver.py
@@ -58,7 +58,7 @@ class StackdriverMetrics(Metrics):
             "minutes": "min",
             "hours": "h",
             "days": "d",
-            None: None
+            None: None,
         }
         self.value_types_map = {
             int: MetricDescriptor.INT64,
@@ -83,20 +83,24 @@ class StackdriverMetrics(Metrics):
                 prepared_metric_dict.pop("metric_type")
             ]
             prepared_metric_dict["value_type"] = self.value_types_map[
-                prepared_metric_dict.pop("value_type")]
+                prepared_metric_dict.pop("value_type")
+            ]
 
             prepared_metric_dict["unit"] = self.units_map[
-                prepared_metric_dict["unit"]]
+                prepared_metric_dict["unit"]
+            ]
 
-            stackdriver_metric_name = f"custom.googleapis.com/" \
+            stackdriver_metric_name = (
+                f"custom.googleapis.com/"
                 f"{self.metrics_registry.metric_set}/{metric_name}"
+            )
 
             prepared_metrics[stackdriver_metric_name] = prepared_metric_dict
 
         return prepared_metrics
 
     def _create_metric_descriptor(
-            self, metric_kind, value_type, metric_name, unit
+        self, metric_kind, value_type, metric_name, unit
     ):
         """
         Creates metric descriptor.
@@ -187,10 +191,7 @@ class StackdriverMetrics(Metrics):
         """
         time_series_list = []
 
-        for (
-                metric_name,
-                metric_dict,
-        ) in self.prepared_metrics.items():
+        for metric_name, metric_dict in self.prepared_metrics.items():
             metric_dict_copy = metric_dict.copy()
             value = metric_dict_copy.pop("value")
 


### PR DESCRIPTION
This slightly differs from task's title.

`prepared_metrics` property now calls `prepare_metrics`, and `prepare_metrics` now just returns prepared metrics instead of using `_prepared_metrics` attribute.

Also, there is some `black` formatting fixes.