### PR TITLE
updated order of arguments in order to have the usage display full a…

### DIFF
--- a/common/__init__.py
+++ b/common/__init__.py
@@ -27,35 +27,37 @@ def root_parser():
     )
     parser.set_defaults(force=False)
     parser.add_argument(
-        "-a",
         "--api-url",
+        "-a",
         help="URL to GitHub API",
         default=SETTINGS.DEFAULT_GITHUB_API_URL,
     )
     parser.add_argument(
-        "-o",
         "--code-org",
+        "-o",
         help="ID of the organisation where the Terraform code" "repository is",
         default=SETTINGS.DEFAULT_CODE_ORG,
     )
     parser.add_argument(
-        "-O",
         "--config-org",
+        "-O",
         help="ID of the organisation where the configuration" "repository is",
         default=SETTINGS.DEFAULT_CONFIG_ORG,
     )
     parser.add_argument(
-        "-t", "--vcs-token", help="Authentication for VCS platform"
+        "--vcs-token",
+        "-t",
+        help="Authentication for VCS platform"
     )
     parser.add_argument(
-        "-c",
         "--config-version",
+        "-c",
         help="git branch for the configuration",
         default=SETTINGS.DEFAULT_GIT_REF,
     )
     parser.add_argument(
-        "-T",
         "--code-version",
+        "-T",
         help="git branch for the code",
         default=SETTINGS.DEFAULT_GIT_REF,
     )
@@ -98,11 +100,13 @@ def root_parser():
         action="store_true",
     )
     parser.add_argument(
-        "-st", "--slack-token", help="Slack bot user OAuth access token"
+        "--slack-token",
+        "-st",
+        help="Slack bot user OAuth access token"
     )
     parser.add_argument(
-        "-sc",
         "--slack-channel",
+        "-sc",
         help="Name of channel, where notifications will go",
     )
     parser.add_argument(


### PR DESCRIPTION
updated order of arguments in order to have the usage display full argument rather than short version 

usage: cloudctl [-h] [--api-url API_URL] [--code-org CODE_ORG]
                [--config-org CONFIG_ORG] [--vcs-token VCS_TOKEN]
                [--config-version CONFIG_VERSION]
                [--code-version CODE_VERSION] [--key-file KEY_FILE]
                [--monitoring-namespace MONITORING_NAMESPACE]
                [--log-file LOG_FILE] [--metrics-file METRICS_FILE]
                [--debug DEBUG] [--disable-local-reporter] [--json-logging]
                [--slack-token SLACK_TOKEN] [--slack-channel SLACK_CHANNEL]
                [--vcs-platform {all,github}] [--notification-system {slack}]
                [--monitoring-system {stackdriver,cloudwatch,zabbix}]
                {deploy,config} ...
